### PR TITLE
Fix CreateHost funtion to working with Icinga2 - Groups is required i…

### DIFF
--- a/iapi/hosts.go
+++ b/iapi/hosts.go
@@ -33,13 +33,14 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 }
 
 // CreateHost ...
-func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string, templates []string) ([]HostStruct, error) {
+func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string, templates []string, groups []string) ([]HostStruct, error) {
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
 	newAttrs.CheckCommand = "hostalive"
 	newAttrs.Vars = variables
 	newAttrs.Templates = templates
+	newAttrs.Groups = groups
 
 	var newHost HostStruct
 	newHost.Name = hostname

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -27,7 +27,8 @@ func TestCreateSimpleHost(t *testing.T) {
 	hostname := "go-icinga2-api-1"
 	IPAddress := "127.0.0.2"
 	CheckCommand := "CheckItRealGood"
-	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil)
+	Group := []string{"linux-servers"}
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil, Group)
 
 	if err != nil {
 		t.Error(err)
@@ -39,12 +40,13 @@ func TestCreateHostWithVariables(t *testing.T) {
 	hostname := "go-icinga2-api-2"
 	IPAddress := "127.0.0.3"
 	CheckCommand := "CheckItRealGood"
+	Group := []string{"linux-servers"}
 	variables := make(map[string]string)
 
 	variables["vars.os"] = "Linux"
 	variables["vars.creator"] = "Terraform"
 
-	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, variables, nil)
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, variables, nil, Group)
 	if err != nil {
 		t.Error(err)
 	}
@@ -60,9 +62,10 @@ func TestCreateHostWithTemplates(t *testing.T) {
 	hostname := "go-icinga2-api-2"
 	IPAddress := "127.0.0.3"
 	CheckCommand := "CheckItRealGood"
+	Group := []string{"linux-servers"}
 	templates := []string{"template1", "template2"}
 
-	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, templates)
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, templates, Group)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iapi/services_test.go
+++ b/iapi/services_test.go
@@ -53,8 +53,9 @@ func TestCreateHostAndService(t *testing.T) {
 	hostname := "c1-test-1"
 	servicename := "ssh"
 	check_command := "ssh"
+	Group := []string{"linux-servers"}
 
-	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil)
+	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil, Group)
 
 	_, err := Icinga2_Server.CreateService(servicename, hostname, check_command)
 


### PR DESCRIPTION
When creating a host the Icinga2 API requires that you pass a group back as well, this causes the issues seen here: 

https://github.com/terraform-providers/terraform-provider-icinga2/issues/1

I have also corrected the provider but this is a required change before pushing the provider changes. 