### PR TITLE
Fix CheckCommand value in hosts

### DIFF
--- a/iapi/hosts.go
+++ b/iapi/hosts.go
@@ -37,7 +37,7 @@ func (server *Server) CreateHost(hostname, address, checkCommand string, variabl
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
-	newAttrs.CheckCommand = "hostalive"
+	newAttrs.CheckCommand = checkCommand
 	newAttrs.Vars = variables
 	newAttrs.Templates = templates
 	newAttrs.Groups = groups

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -40,7 +40,7 @@ func TestCreateHostWithVariables(t *testing.T) {
 	hostname := "go-icinga2-api-2"
 	IPAddress := "127.0.0.3"
 	CheckCommand := "hostalive"
-	Group := []string{"linux-servers"}
+
 	variables := make(map[string]string)
 
 	variables["vars.os"] = "Linux"
@@ -62,7 +62,7 @@ func TestCreateHostWithTemplates(t *testing.T) {
 	hostname := "go-icinga2-api-2"
 	IPAddress := "127.0.0.3"
 	CheckCommand := "hostalive"
-	Group := []string{"linux-servers"}
+
 	templates := []string{"template1", "template2"}
 
 	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, templates, nil)
@@ -80,7 +80,7 @@ func TestCreateHostWithTemplates(t *testing.T) {
 func TestCreateHostWithGroup(t *testing.T) {
         hostname := "go-icinga2-api-2"
         IPAddress := "127.0.0.3"
-        CheckCommand := "CheckItRealGood"
+        CheckCommand := "hostalive"
         Group := []string{"linux-servers"}
 
         _, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil, Group)

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -27,7 +27,7 @@ func TestCreateSimpleHost(t *testing.T) {
 	hostname := "go-icinga2-api-1"
 	IPAddress := "127.0.0.2"
 	CheckCommand := "hostalive"
-	Group := []string{"linux-servers"}
+
 	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil, nil )
 
 	if err != nil {

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -26,7 +26,7 @@ func TestCreateSimpleHost(t *testing.T) {
 
 	hostname := "go-icinga2-api-1"
 	IPAddress := "127.0.0.2"
-	CheckCommand := "CheckItRealGood"
+	CheckCommand := "hostalive"
 	Group := []string{"linux-servers"}
 	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil, Group)
 
@@ -39,7 +39,7 @@ func TestCreateHostWithVariables(t *testing.T) {
 
 	hostname := "go-icinga2-api-2"
 	IPAddress := "127.0.0.3"
-	CheckCommand := "CheckItRealGood"
+	CheckCommand := "hostalive"
 	Group := []string{"linux-servers"}
 	variables := make(map[string]string)
 
@@ -61,7 +61,7 @@ func TestCreateHostWithVariables(t *testing.T) {
 func TestCreateHostWithTemplates(t *testing.T) {
 	hostname := "go-icinga2-api-2"
 	IPAddress := "127.0.0.3"
-	CheckCommand := "CheckItRealGood"
+	CheckCommand := "hostalive"
 	Group := []string{"linux-servers"}
 	templates := []string{"template1", "template2"}
 


### PR DESCRIPTION
According to Terraform documentation (https://www.terraform.io/docs/providers/icinga2/r/host.html) it should be possible to adjust `check_command` argument in `icinga2_host` resource but it was hardcoded in the library. This PR fixes that problem.