### PR TITLE
Adding IPv6 support

### DIFF
--- a/iapi/hosts.go
+++ b/iapi/hosts.go
@@ -33,18 +33,19 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 }
 
 // CreateHost ...
-func (server *Server) CreateHost(hostname, address, checkCommand string, variables map[string]string, templates []string, groups []string) ([]HostStruct, error) {
+func (server *Server) CreateHost(hostname, address, address6 string, checkCommand string, variables map[string]string, templates []string, groups []string) ([]HostStruct, error) {
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
+	newAttrs.Address6 = address6
 	newAttrs.CheckCommand = checkCommand
 	newAttrs.Vars = variables
 	newAttrs.Templates = templates
 
-        if groups == nil {
-          groups = []string{} 
-        }
-        newAttrs.Groups = groups
+	if groups == nil {
+		groups = []string{}
+	}
+	newAttrs.Groups = groups
 
 	var newHost HostStruct
 	newHost.Name = hostname

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -28,7 +28,21 @@ func TestCreateSimpleHost(t *testing.T) {
 	IPAddress := "127.0.0.2"
 	CheckCommand := "hostalive"
 
-	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil, nil )
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, "", CheckCommand, nil, nil, nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCreateSimpleIPv6Host(t *testing.T) {
+
+	hostname := "go-icinga2-api-3"
+	IPAddress := "127.0.0.2"
+	IP6Address := "::1"
+	CheckCommand := "hostalive"
+
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, IP6Address, CheckCommand, nil, nil, nil)
 
 	if err != nil {
 		t.Error(err)
@@ -46,7 +60,7 @@ func TestCreateHostWithVariables(t *testing.T) {
 	variables["vars.os"] = "Linux"
 	variables["vars.creator"] = "Terraform"
 
-	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, variables, nil, nil)
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, "", CheckCommand, variables, nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -65,7 +79,7 @@ func TestCreateHostWithTemplates(t *testing.T) {
 
 	templates := []string{"template1", "template2"}
 
-	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, templates, nil)
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, "", CheckCommand, nil, templates, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -78,21 +92,21 @@ func TestCreateHostWithTemplates(t *testing.T) {
 }
 
 func TestCreateHostWithGroup(t *testing.T) {
-        hostname := "go-icinga2-api-2"
-        IPAddress := "127.0.0.3"
-        CheckCommand := "hostalive"
-        Group := []string{"linux-servers"}
+	hostname := "go-icinga2-api-2"
+	IPAddress := "127.0.0.3"
+	CheckCommand := "hostalive"
+	Group := []string{"linux-servers"}
 
-        _, err := Icinga2_Server.CreateHost(hostname, IPAddress, CheckCommand, nil, nil, Group)
-        if err != nil {
-                t.Error(err)
-        }
+	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, "", CheckCommand, nil, nil, Group)
+	if err != nil {
+		t.Error(err)
+	}
 
-        // Delete host after creating it.
-        deleteErr := Icinga2_Server.DeleteHost(hostname)
-        if deleteErr != nil {
-                t.Error(err)
-        }
+	// Delete host after creating it.
+	deleteErr := Icinga2_Server.DeleteHost(hostname)
+	if deleteErr != nil {
+		t.Error(err)
+	}
 }
 func TestDeleteHost(t *testing.T) {
 

--- a/iapi/notifications_test.go
+++ b/iapi/notifications_test.go
@@ -216,5 +216,4 @@ func TestNotifications(t *testing.T) {
 			}
 		})
 	})
->>>>>>> master
 }

--- a/iapi/notifications_test.go
+++ b/iapi/notifications_test.go
@@ -84,7 +84,7 @@ func TestCreateNotificationUserDNE(t *testing.T) {
 	interval := 1800
 	users := []string{"user-dne"}
 
-	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil, group)
+	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "", "hostalive", nil, nil, group)
 	_, err := Icinga2_Server.CreateNotification(notificationname, hostname, command, servicename, interval, users, nil, nil)
 
 	if !strings.Contains(err.Error(), "500 Object could not be created") {
@@ -102,7 +102,7 @@ func TestCreateHostNotification(t *testing.T) {
 	interval := 1800
 	username := "user"
 
-	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil, groups)
+	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "", "hostalive", nil, nil, groups)
 	_, _ = Icinga2_Server.CreateUser(username, "user@example.com")
 	_, err := Icinga2_Server.CreateNotification(notificationname, hostname, command, servicename, interval, []string{username}, nil, nil)
 

--- a/iapi/notifications_test.go
+++ b/iapi/notifications_test.go
@@ -79,7 +79,7 @@ func TestNotifications(t *testing.T) {
 			interval := 1800
 			users := []string{"user-dne"}
 
-			_, _ = icingaServer.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil, group)
+			_, _ = icingaServer.CreateHost(hostname, "127.0.0.1", "", "hostalive", nil, nil, group)
 			_, err := icingaServer.CreateNotification(notificationname, hostname, command, servicename, interval, users, nil, nil)
 
 			if err == nil {
@@ -96,7 +96,7 @@ func TestNotifications(t *testing.T) {
 			interval := 1800
 			username := "user"
 
-			_, _ = icingaServer.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil, groups)
+			_, _ = icingaServer.CreateHost(hostname, "127.0.0.1", "", "hostalive", nil, nil, groups)
 			_, _ = icingaServer.CreateUser(username, "user@example.com")
 			_, err := icingaServer.CreateNotification(notificationname, hostname, command, servicename, interval, []string{username}, nil, nil)
 			if err != nil {

--- a/iapi/services_test.go
+++ b/iapi/services_test.go
@@ -7,7 +7,7 @@ import (
 func TestServices(t *testing.T) {
 	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 	testHostName := "c1-mysql-1"
-	_, err := icingaServer.CreateHost(testHostName, "127.0.0.1", nil, "hostalive", nil, nil, nil)
+	_, err := icingaServer.CreateHost(testHostName, "127.0.0.1", "", "hostalive", nil, nil, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/iapi/services_test.go
+++ b/iapi/services_test.go
@@ -55,7 +55,7 @@ func TestCreateHostAndService(t *testing.T) {
 	check_command := "ssh"
 	Group := []string{"linux-servers"}
 
-	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "hostalive", nil, nil, Group)
+	_, _ = Icinga2_Server.CreateHost(hostname, "127.0.0.1", "", "hostalive", nil, nil, Group)
 
 	_, err := Icinga2_Server.CreateService(servicename, hostname, check_command, nil)
 


### PR DESCRIPTION
This adds IPv6 support with the IPv6 address being optional.

Added a simple test and this appears to pass. Adding this to
follow up with adding IPv6 support to the Terraform provider.