### PR TITLE
Feature: support Icinga2 Config Management API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ docker_clean:
 
 test:
 	$(eval password:=$(shell docker exec icinga2 bash -c 'grep password /etc/icinga2/conf.d/api-users.conf' | awk -F'"' '{ print $$2}' ))
-	( export ICINGA2_API_PASSWORD="$(password)" && go test ./... -v  )
+	( export ICINGA2_API_USER="icinga-test" ICINGA2_API_USER_ROOT="root" ICINGA2_API_PASSWORD="$(password)" && go test ./... -v  )

--- a/iapi/client.go
+++ b/iapi/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"io"
 	"net/http"
 	"time"
 )
@@ -61,6 +62,43 @@ func (server *Server) Connect() error {
 	defer response.Body.Close()
 
 	return nil
+}
+
+func (server *Server) NewPlainTextRequest(method, APICall string, jsonString []byte) (string, error) {
+	fullURL := server.BaseURL + APICall
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: server.AllowUnverifiedSSL,
+		},
+	}
+
+	server.httpClient = &http.Client{
+		Transport: t,
+		Timeout:   time.Second * 60,
+	}
+
+	request, requestErr := http.NewRequest(method, fullURL, bytes.NewBuffer(jsonString))
+	if requestErr != nil {
+		return "", requestErr
+	}
+
+	request.SetBasicAuth(server.Username, server.Password)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, doErr := server.httpClient.Do(request)
+	if doErr != nil {
+		return "", doErr
+	}
+	defer response.Body.Close()
+
+	bodyBytes, err := io.ReadAll(response.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(bodyBytes), nil
 }
 
 // NewAPIRequest ...

--- a/iapi/client_test.go
+++ b/iapi/client_test.go
@@ -6,14 +6,16 @@ import (
 )
 
 var ICINGA2_API_PASSWORD = os.Getenv("ICINGA2_API_PASSWORD")
+var ICINGA2_API_USER = os.Getenv("ICINGA2_API_USER")
+var ICINGA2_API_USER_ROOT = os.Getenv("ICINGA2_API_USER_ROOT")
 
-var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 
-//var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:5665/v1", true, nil}
+//var Icinga2_Server = Server{ICINGA2_API_USER, "icinga", "https://127.0.0.1:5665/v1", true, nil}
 
 func TestConnect(t *testing.T) {
 
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:5665/v1", true, nil}
+	var Icinga2_Server = Server{ICINGA2_API_USER, "icinga", "https://127.0.0.1:5665/v1", true, nil}
 	Icinga2_Server.Connect()
 
 	if Icinga2_Server.httpClient == nil {
@@ -23,7 +25,7 @@ func TestConnect(t *testing.T) {
 
 func TestConnectServerUnavailable(t *testing.T) {
 
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", true, nil}
+	var Icinga2_Server = Server{ICINGA2_API_USER, "icinga", "https://127.0.0.1:4665/v1", true, nil}
 	err := Icinga2_Server.Connect()
 
 	if err == nil {
@@ -51,7 +53,7 @@ func TestNewAPIRequest(t *testing.T) {
 
 func TestConnectServerBadURINoVersion(t *testing.T) {
 
-	var Icinga2_Server = Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", true, nil}
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", true, nil}
 	result, _ := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
 
 	if result.Code != 404 {

--- a/iapi/config.go
+++ b/iapi/config.go
@@ -112,6 +112,19 @@ func (server *Server) CreateConfigStage(packagename string, files map[string]str
 	return nil, fmt.Errorf("%s", results.ErrorString)
 }
 
+func (server *Server) DeleteConfigStage(packagename string, stage string) error {
+	results, err := server.NewAPIRequest("DELETE", "/config/stages/"+packagename+"/"+stage, nil)
+	if err != nil {
+		return err
+	}
+
+	if results.Code == 200 {
+		return nil
+	}
+
+	return fmt.Errorf("%s", results.ErrorString)
+}
+
 func (server *Server) DetermineLogStatus(log string) bool {
 	lines := strings.Split(log, "\n")
 	var lastLine string

--- a/iapi/config.go
+++ b/iapi/config.go
@@ -1,0 +1,177 @@
+package iapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func (server *Server) GetConfigPackages() ([]ConfigPackageStruct, error) {
+	var packages []ConfigPackageStruct
+
+	results, err := server.NewAPIRequest("GET", "/config/packages", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonStr, marshalErr := json.Marshal(results.Results)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	if unmarshalErr := json.Unmarshal(jsonStr, &packages); unmarshalErr != nil {
+		return nil, unmarshalErr
+	}
+
+	return packages, err
+}
+
+func (server *Server) GetConfigPackage(packagename string) ([]ConfigPackageStruct, error) {
+	var packages []ConfigPackageStruct
+
+	packages, err := server.GetConfigPackages()
+
+	if err != nil {
+		return nil, err
+	}
+	if packages == nil {
+		return nil, fmt.Errorf("Empty struct")
+	}
+	for _, item := range packages {
+		if item.Name == packagename {
+			var packResult []ConfigPackageStruct
+			return append(packResult, item), nil
+		}
+	}
+
+	return nil, fmt.Errorf("Package %s not found", packagename)
+}
+
+func (server *Server) CreateConfigPackage(packagename string) ([]ConfigPackageStruct, error) {
+	results, err := server.NewAPIRequest("POST", "/config/packages/"+packagename, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if results.Code == 200 {
+		return server.GetConfigPackage(packagename)
+	}
+
+	return nil, fmt.Errorf("%s", results.ErrorString)
+}
+
+func (server *Server) DeleteConfigPackage(packagename string) error {
+	results, err := server.NewAPIRequest("DELETE", "/config/packages/"+packagename, nil)
+	if err != nil {
+		return err
+	}
+
+	if results.Code == 200 {
+		return nil
+	}
+
+	return fmt.Errorf("%s", results.ErrorString)
+}
+
+func (server *Server) CreateConfigStage(packagename string, files map[string]string, reload bool, activate bool) ([]ConfigStageStruct, error) {
+	if !activate && reload {
+		return nil, fmt.Errorf("if activate is set to false, reload must also be set to false")
+	}
+
+	var newAttrs ConfigStageAttrs
+	newAttrs.Files = files
+	newAttrs.Activate = activate
+	newAttrs.Reload = reload
+
+	payloadJSON, marshalErr := json.Marshal(newAttrs)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+
+	results, err := server.NewAPIRequest("POST", "/config/stages/"+packagename, []byte(payloadJSON))
+	if err != nil {
+		return nil, err
+	}
+
+	if results.Code == 200 {
+		jsonStr, marshalErr := json.Marshal(results.Results)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+
+		var stages []ConfigStageStruct
+
+		if unmarshalErr := json.Unmarshal(jsonStr, &stages); unmarshalErr != nil {
+			return nil, unmarshalErr
+		}
+
+		return stages, err
+	}
+
+	return nil, fmt.Errorf("%s", results.ErrorString)
+}
+
+func (server *Server) DetermineLogStatus(log string) bool {
+	lines := strings.Split(log, "\n")
+	var lastLine string
+	for _, line := range lines {
+		if len(strings.TrimSpace(line)) > 0 {
+			lastLine = line
+		}
+	}
+	return strings.Contains(lastLine, "Finished")
+}
+
+func (server *Server) CreateConfigStageRetriable(packagename string, files map[string]string, reload bool, activate bool, retryCount int, delayMS time.Duration) ([]ConfigStageStruct, error) {
+	var globalerr error
+	for i := 1; i < retryCount; i++ {
+		stages, err := server.CreateConfigStage(packagename, files, reload, activate)
+		if err == nil {
+			log, err := server.GetConfigStageFile(packagename, stages[0].Name, "startup.log")
+			if err != nil {
+				return nil, err
+			}
+			stages[0].Log = log
+			stages[0].Successful = server.DetermineLogStatus(log)
+
+			return stages, nil
+		}
+		time.Sleep(delayMS * time.Millisecond)
+		globalerr = err
+	}
+	return nil, globalerr
+}
+
+func (server *Server) ListConfigStageFiles(packagename string, stage string) ([]ConfigStageFileStruct, error) {
+	results, err := server.NewAPIRequest("GET", "/config/stages/"+packagename+"/"+stage, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if results.Code == 200 {
+		jsonStr, marshalErr := json.Marshal(results.Results)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+
+		var files []ConfigStageFileStruct
+
+		if unmarshalErr := json.Unmarshal(jsonStr, &files); unmarshalErr != nil {
+			return nil, unmarshalErr
+		}
+
+		return files, err
+	}
+
+	return nil, fmt.Errorf("%s", results.ErrorString)
+}
+
+func (server *Server) GetConfigStageFile(packagename string, stage string, file string) (string, error) {
+	result, err := server.NewPlainTextRequest("GET", "/config/files/"+packagename+"/"+stage+"/"+file, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}

--- a/iapi/config_test.go
+++ b/iapi/config_test.go
@@ -121,6 +121,39 @@ func TestConfigListStageFiles(t *testing.T) {
 	t.Error("Configuration file not found in active stage!")
 }
 
+func TestConfigCreateSecondStage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	var files = make(map[string]string)
+	files["conf.d/test-host.conf"] = `object Host "test-host" {
+		display_name = "Test Host Updated"
+		address = "172.0.0.1"
+
+		check_command = "hostalive"
+	}`
+
+	stages, err := Icinga2_Server.CreateConfigStageRetriable(
+		packagename,
+		files,
+		true,
+		true,
+		5,
+		1000,
+	)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !stages[0].Successful {
+		t.Error("Stage unsuccessful")
+		return
+	}
+}
+
 func TestConfigCreateBrokenStage(t *testing.T) {
 	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 
@@ -150,6 +183,25 @@ func TestConfigCreateBrokenStage(t *testing.T) {
 
 	if stages[0].Successful {
 		t.Error("Broken Stage Error was not detected!")
+	}
+}
+
+func TestConfigDeleteStage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	packages, err := Icinga2_Server.GetConfigPackage(packagename)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = Icinga2_Server.DeleteConfigStage(packagename, packages[0].Stages[0])
+
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/iapi/config_test.go
+++ b/iapi/config_test.go
@@ -1,0 +1,173 @@
+package iapi
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestConfigListPackages(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	packages, err := Icinga2_Server.GetConfigPackages()
+
+	if len(packages) < 1 {
+		t.Error(fmt.Errorf("%d packages found", len(packages)))
+	}
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestConfigGetPackage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	packages, err := Icinga2_Server.GetConfigPackages()
+
+	if len(packages) < 1 {
+		t.Error(fmt.Errorf("%d packages found", len(packages)))
+		return
+	}
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	pack, packErr := Icinga2_Server.GetConfigPackage(packages[0].Name)
+
+	if packErr != nil {
+		t.Error(packErr)
+		return
+	}
+
+	if pack[0].Name != packages[0].Name {
+		t.Error(fmt.Errorf("Package name does not match request"))
+		return
+	}
+}
+
+func TestConfigCreatePackage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	packages, err := Icinga2_Server.CreateConfigPackage(packagename)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if packagename != packages[0].Name {
+		t.Error(fmt.Errorf("Package name does not match request"))
+		return
+	}
+}
+
+func TestConfigCreateStage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	var files = make(map[string]string)
+	files["conf.d/test-host.conf"] = `object Host "test-host" {
+		display_name = "Test Host"
+		address = "127.0.0.1"
+
+		check_command = "hostalive"
+	}`
+
+	stages, err := Icinga2_Server.CreateConfigStageRetriable(
+		packagename,
+		files,
+		true,
+		true,
+		5,
+		1000,
+	)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if !stages[0].Successful {
+		t.Error("Stage unsuccessful")
+		return
+	}
+}
+
+func TestConfigListStageFiles(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	packages, err := Icinga2_Server.GetConfigPackage(packagename)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	files, err := Icinga2_Server.ListConfigStageFiles(packagename, packages[0].ActiveStage)
+
+	for _, file := range files {
+		if file.Name == "conf.d/test-host.conf" && file.Type == "file" {
+			return
+		}
+	}
+
+	t.Error("Configuration file not found in active stage!")
+}
+
+func TestConfigCreateBrokenStage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	var files = make(map[string]string)
+	files["conf.d/test-host.conf"] = `object DoesNotExist "test-host" {
+		display_name = "Test Host"
+		address = "127.0.0.1"
+
+		check_command = "hostalive"
+	}`
+
+	stages, err := Icinga2_Server.CreateConfigStageRetriable(
+		packagename,
+		files,
+		true,
+		true,
+		5,
+		1000,
+	)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if stages[0].Successful {
+		t.Error("Broken Stage Error was not detected!")
+	}
+}
+
+func TestConfigDeletePackage(t *testing.T) {
+	var Icinga2_Server = Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+
+	var packagename = "test-package"
+
+	err := Icinga2_Server.DeleteConfigPackage(packagename)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	_, err = Icinga2_Server.GetConfigPackage(packagename)
+
+	if err == nil {
+		t.Error("Package could be found after delete")
+	}
+}

--- a/iapi/hostgroups_test.go
+++ b/iapi/hostgroups_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestHostgroups(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 	t.Run("Create", func(t *testing.T) {
 		t.Run("Hostgroup", func(t *testing.T) {
 			name := "docker-servers"

--- a/iapi/notifications_test.go
+++ b/iapi/notifications_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestNotifications(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 	// testHostName := "notification-test-host"
 	// _, err := icingaServer.CreateHost(testHostName, "127.0.0.1", "hostalive", nil, nil, nil)
 	// if err != nil {

--- a/iapi/services_test.go
+++ b/iapi/services_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestServices(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 	testHostName := "c1-mysql-1"
 	_, err := icingaServer.CreateHost(testHostName, "127.0.0.1", "", "hostalive", nil, nil, nil)
 	if err != nil {

--- a/iapi/structs.go
+++ b/iapi/structs.go
@@ -172,7 +172,6 @@ type ConfigStageAttrs struct {
 type ConfigStageStruct struct {
 	Package    string `json:"package"`
 	Name       string `json:"stage"`
-	Status     string `json:"status"`
 	Log        string
 	Successful bool
 }

--- a/iapi/structs.go
+++ b/iapi/structs.go
@@ -9,7 +9,7 @@ duplicate or near duplicate defintions of structs are being defined but can be r
 be in place to ensure everything still works.
 */
 
-//ServiceStruct stores service results
+// ServiceStruct stores service results
 type ServiceStruct struct {
 	Attrs ServiceAttrs `json:"attrs"`
 	Joins struct{}     `json:"joins"`
@@ -140,7 +140,7 @@ type UserAttrs struct {
 	Email string `json:"email"`
 }
 
-//NotificationStruct stores notification results
+// NotificationStruct stores notification results
 type NotificationStruct struct {
 	Attrs NotificationAttrs `json:"attrs"`
 	Joins struct{}          `json:"joins"`
@@ -155,4 +155,29 @@ type NotificationAttrs struct {
 	Interval    int         `json:"interval"`
 	Vars        interface{} `json:"vars"`
 	Templates   []string    `json:"templates"`
+}
+
+type ConfigPackageStruct struct {
+	Name        string   `json:"name"`
+	ActiveStage string   `json:"active-stage"`
+	Stages      []string `json:"stages"`
+}
+
+type ConfigStageAttrs struct {
+	Files    map[string]string `json:"files"`
+	Reload   bool              `json:"reload"`
+	Activate bool              `json:"Activate"`
+}
+
+type ConfigStageStruct struct {
+	Package    string `json:"package"`
+	Name       string `json:"stage"`
+	Status     string `json:"status"`
+	Log        string
+	Successful bool
+}
+
+type ConfigStageFileStruct struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
 }

--- a/iapi/users_test.go
+++ b/iapi/users_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestUser(t *testing.T) {
-	icingaServer := Server{"root", ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
+	icingaServer := Server{ICINGA2_API_USER_ROOT, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665/v1", true, nil}
 	t.Run("Create", func(t *testing.T) {
 		t.Run("SimpleUser", func(t *testing.T) {
 			username := "test-user"


### PR DESCRIPTION
This PR adds support for the [Configuration Management API](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#configuration-management) to deploy DSL Configuration through the API and check stage results.