### PR TITLE
Update CreateHost variables to accept interface instead of string

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721379653,
+        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
+        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
+        "revCount": 655136,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.655136%2Brev-1d9c2c9b3e71b9ee663d11c5d298727dace8d374/0190cd4f-c0eb-72cb-834b-ac854aa282dc/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "A Nix-flake-based Go 1.22 development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+
+  outputs = { self, nixpkgs }:
+    let
+      goVersion = 22; # Change this to update the whole stack
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        };
+      });
+    in
+    {
+      overlays.default = final: prev: {
+        go = final."go_1_${toString goVersion}";
+      };
+
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # go (version is specified by overlay)
+            go
+
+            # goimports, godoc, etc.
+            gotools
+
+            # https://github.com/golangci/golangci-lint
+            golangci-lint
+          ];
+        };
+      });
+    };
+}

--- a/iapi/hosts.go
+++ b/iapi/hosts.go
@@ -33,7 +33,7 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 }
 
 // CreateHost ...
-func (server *Server) CreateHost(hostname, address, address6 string, checkCommand string, variables map[string]string, templates []string, groups []string) ([]HostStruct, error) {
+func (server *Server) CreateHost(hostname, address, address6 string, checkCommand string, variables map[string]interface{}, templates []string, groups []string) ([]HostStruct, error) {
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -55,10 +55,11 @@ func TestCreateHostWithVariables(t *testing.T) {
 	IPAddress := "127.0.0.3"
 	CheckCommand := "hostalive"
 
-	variables := make(map[string]string)
+	variables := make(map[string]interface{})
 
 	variables["vars.os"] = "Linux"
 	variables["vars.creator"] = "Terraform"
+	variables["vars.urls"] = []string{"test-url1.example.com", "test-url2.example.com"}
 
 	_, err := Icinga2_Server.CreateHost(hostname, IPAddress, "", CheckCommand, variables, nil, nil)
 	if err != nil {


### PR DESCRIPTION
The Icinga API documentation mentions that it accepts a dict for the `vars` attribute of a Host object. The `HostAttrs` struct also accepts an interface, this changes brings `CreateHost` to match with `map[string]interface{}` instead of forcing the limited scope of `map[string]string`

I updated the tests and ran them locally, and they passed, though admittedly I ran them manually as I am not entirely sure how to use the Makefile.

This is a precursor to attempting to fix the downstream Terraform provider that does not accept anything other than a string: Icinga/terraform-provider-icinga2#88

Let me know if I am missing anything!