### PR TITLE
refactor: Host and Hostgroup management

### DIFF
--- a/iapi/downtimes.go
+++ b/iapi/downtimes.go
@@ -46,7 +46,7 @@ func (server *Server) ScheduleDowntime(t string, filter string, author string, c
 	var results []DowntimeScheduleResponse
 	err = json.Unmarshal(jsonResponse, &results)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall the downtime response: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal the downtime response: %v", err)
 	}
 
 	var names []string
@@ -86,7 +86,7 @@ func (server *Server) RemoveDowntime(downtime string, author string) error {
 	var results []DowntimeRemoveResponse
 	err = json.Unmarshal(jsonResponse, &results)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshall the downtime response: %v", err)
+		return fmt.Errorf("failed to unmarshal the downtime response: %v", err)
 	}
 
 	for _, result := range results {

--- a/iapi/hostgroups.go
+++ b/iapi/hostgroups.go
@@ -9,11 +9,6 @@ import (
 
 const hostgroupEndpoint = "/objects/hostgroups"
 
-// HostgroupParams defines all available options related to updating a HostGroup.
-type HostgroupParams struct {
-	DisplayName string
-}
-
 // GetHostgroup fetches a HostGroup by its name.
 func (server *Server) GetHostgroup(name string) ([]HostgroupStruct, error) {
 	endpoint := fmt.Sprintf("%v/%v", hostgroupEndpoint, name)
@@ -76,34 +71,44 @@ func (server *Server) CreateHostgroup(name, displayName, zone string) ([]Hostgro
 	return nil, fmt.Errorf("%s", results.ErrorString)
 }
 
-// UpdateHostgroup updates a HostGroup with its params.
-func (server *Server) UpdateHostgroup(name string, params *HostgroupParams) ([]HostgroupStruct, error) {
-	attrs := make(map[string]interface{})
-	if params.DisplayName != "" {
-		attrs["display_name"] = params.DisplayName
-	}
+// UpdateHostgroup updates a HostGroup with its attrs.
+func (server *Server) UpdateHostgroup(name string, attrs HostgroupAttrs) ([]HostgroupStruct, error) {
+	var hostgroup HostgroupStruct
+	hostgroup.Attrs = attrs
 
-	attrsMap := map[string]interface{}{
-		"attrs": attrs,
-	}
-
-	attrsBody, err := json.Marshal(attrsMap)
+	body, err := json.Marshal(hostgroup)
 	if err != nil {
 		return nil, err
 	}
 
 	endpoint := fmt.Sprintf("%v/%v", hostgroupEndpoint, name)
-	results, err := server.NewAPIRequest(http.MethodPost, endpoint, attrsBody)
+	r, err := server.NewAPIRequest(http.MethodPost, endpoint, body)
 	if err != nil {
 		return nil, err
 	}
 
-	if results.Code == http.StatusOK {
-		hostgroups, err := server.GetHostgroup(name)
-		return hostgroups, err
+	if r.Code != http.StatusOK {
+		return nil, fmt.Errorf("expected %d, got %d", http.StatusOK, r.Code)
 	}
 
-	return nil, fmt.Errorf("%s", results.ErrorString)
+	jsonResponse, err := json.Marshal(r.Results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the host group response: %v", err)
+	}
+
+	var results []HostgroupUpdateResult
+	err = json.Unmarshal(jsonResponse, &results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the host group response: %v", err)
+	}
+
+	for _, result := range results {
+		if result.Code != http.StatusOK {
+			return nil, fmt.Errorf("%s", result.Status)
+		}
+	}
+
+	return server.GetHostgroup(name)
 }
 
 // DeleteHostgroup deletes a HostGroup by its name.

--- a/iapi/hostgroups_test.go
+++ b/iapi/hostgroups_test.go
@@ -54,10 +54,10 @@ func TestHostgroups(t *testing.T) {
 		defer icingaServer.DeleteHostgroup(hostgroupName)
 
 		secondDisplayName := "other hostgroup display name"
-		params := &HostgroupParams{
+		attrs := HostgroupAttrs{
 			DisplayName: secondDisplayName,
 		}
-		updatedHostgroup, err := icingaServer.UpdateHostgroup(hostgroupName, params)
+		updatedHostgroup, err := icingaServer.UpdateHostgroup(hostgroupName, attrs)
 		if err != nil {
 			t.Error(err)
 		}

--- a/iapi/hosts.go
+++ b/iapi/hosts.go
@@ -3,6 +3,7 @@ package iapi
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 // GetHost ...
@@ -10,7 +11,7 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 
 	var hosts []HostStruct
 
-	results, err := server.NewAPIRequest("GET", "/objects/hosts/"+hostname, nil)
+	results, err := server.NewAPIRequest(http.MethodGet, "/objects/hosts/"+hostname, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +63,7 @@ func (server *Server) CreateHost(hostname, address, address6 string, checkComman
 	//fmt.Printf("<payload> %s\n", payloadJSON)
 
 	// Make the API request to create the hosts.
-	results, err := server.NewAPIRequest("PUT", "/objects/hosts/"+hostname, []byte(payloadJSON))
+	results, err := server.NewAPIRequest(http.MethodPut, "/objects/hosts/"+hostname, []byte(payloadJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +77,50 @@ func (server *Server) CreateHost(hostname, address, address6 string, checkComman
 
 }
 
+// UpdateHost updates a Host with its attrs
+func (server *Server) UpdateHost(name string, attrs HostAttrs) ([]HostStruct, error) {
+
+	host := HostStruct{
+		Attrs: attrs,
+	}
+
+	body, err := json.Marshal(host)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := server.NewAPIRequest(http.MethodPost, "/objects/hosts/"+name, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.Code != http.StatusOK {
+		return nil, fmt.Errorf("expected %d, got %d", http.StatusOK, r.Code)
+	}
+
+	jsonResponse, err := json.Marshal(r.Results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the host response: %v", err)
+	}
+
+	var results []HostUpdateResult
+	err = json.Unmarshal(jsonResponse, &results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the host response: %v", err)
+	}
+
+	for _, result := range results {
+		if result.Code != http.StatusOK {
+			return nil, fmt.Errorf("%s", result.Status)
+		}
+	}
+
+	return server.GetHost(name)
+}
+
 // DeleteHost ...
 func (server *Server) DeleteHost(hostname string) error {
-	results, err := server.NewAPIRequest("DELETE", "/objects/hosts/"+hostname+"?cascade=1", nil)
+	results, err := server.NewAPIRequest(http.MethodDelete, "/objects/hosts/"+hostname+"?cascade=1", nil)
 	if err != nil {
 		return err
 	}

--- a/iapi/structs.go
+++ b/iapi/structs.go
@@ -79,10 +79,10 @@ type HostAttrs struct {
 	Address6     string      `json:"address6"`
 	CheckCommand string      `json:"check_command"`
 	DisplayName  string      `json:"display_name"`
-	Groups       []string    `json:"groups"`
+	Groups       []string    `json:"groups,omitempty"`
 	Notes        string      `json:"notes"`
 	NotesURL     string      `json:"notes_url"`
-	Templates    []string    `json:"templates"`
+	Templates    []string    `json:"templates,omitempty"`
 	Vars         interface{} `json:"vars,omitempty"`
 	Zone         string      `json:"zone,omitempty"`
 }
@@ -95,6 +95,20 @@ type APIResult struct {
 	Code        int         `json:"Code"`
 	Results     interface{} `json:"results"`
 	Retries     int         `json:"Retries"`
+}
+
+// HostgroupUpdateResult stores the API response after updating a Hostgroup
+type HostgroupUpdateResult struct {
+	Code   float64 `json:"code"`
+	Name   string  `json:"name"`
+	Status string  `json:"status"`
+}
+
+// HostUpdateResult stores the API response after updating a Host
+type HostUpdateResult struct {
+	Code   float64 `json:"code"`
+	Name   string  `json:"name"`
+	Status string  `json:"status"`
 }
 
 // APIStatus stores the results of an Icinga2 API Status Call


### PR DESCRIPTION
Icinga can return a HTTP 200 response but with a 500 error and a detailed error message in the response when updating a Host or a Hostgroup. This commit detects those errors and return them.

Use method constants from the "http" module.

Use attrs structs instead of params structs because they have the same definition. Use JSON hints to include optional attributes.

Add a function to update a Host.

Fix typos for "unmarshal" errors.

BREAKING CHANGES:
- HostgroupParams has been removed
- UpdateHostgroup takes a HostgroupAttrs struct instead of *HostgroupParams