### PR TITLE
fix: Retry when Icinga is reloading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/lrsmith/go-icinga2-api
 
 go 1.26.1
+
+require github.com/jarcoal/httpmock v1.4.1
+
+require github.com/cenkalti/backoff/v5 v5.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
+github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
+github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=

--- a/iapi/client.go
+++ b/iapi/client.go
@@ -3,11 +3,17 @@ package iapi
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"strings"
 	"time"
+
+	"github.com/cenkalti/backoff/v5"
 )
 
 // Server ... Use to be ClientConfig
@@ -16,128 +22,114 @@ type Server struct {
 	Password           string
 	BaseURL            string
 	AllowUnverifiedSSL bool
-	Retries            int
+	Tries              int
 	RetryDelay         time.Duration
 	httpClient         *http.Client
 }
 
-func New(username, password, url string, allowUnverifiedSSL bool, retries int, retryDelay time.Duration) (*Server, error) {
-	return &Server{username, password, url, allowUnverifiedSSL, retries, retryDelay, nil}, nil
+func New(username, password, url string, allowUnverifiedSSL bool, tries int, retryDelay time.Duration) (*Server, error) {
+	return &Server{username, password, url, allowUnverifiedSSL, tries, retryDelay, nil}, nil
 }
 
-func (server *Server) Config(username, password, url string, allowUnverifiedSSL bool, retries int, retryDelay time.Duration) (*Server, error) {
+func (server *Server) Config(username, password, url string, allowUnverifiedSSL bool, tries int, retryDelay time.Duration) (*Server, error) {
 	// TODO : Add code to verify parameters
-	return &Server{username, password, url, allowUnverifiedSSL, retries, retryDelay, nil}, nil
+	return &Server{username, password, url, allowUnverifiedSSL, tries, retryDelay, nil}, nil
 }
 
-func (server *Server) doRequest(method, fullURL string, body io.Reader) (*http.Response, int, error) {
-
-	t := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: server.AllowUnverifiedSSL,
-		},
+// createHttpClient defensively creates the HTTP client once
+// and allow httpmock to mock the Transport attribute of the HTTP client
+func (server *Server) createHttpClient() {
+	if server.httpClient == nil {
+		server.httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: server.AllowUnverifiedSSL,
+				},
+			},
+			Timeout: time.Second * 60,
+		}
 	}
+}
 
-	server.httpClient = &http.Client{
-		Transport: t,
-		Timeout:   time.Second * 60,
-	}
+func (server *Server) doRequest(method, fullURL string, body io.Reader) (*http.Response, error) {
+	server.createHttpClient()
 
 	var bodyBytes []byte
 	if body != nil {
 		bodyBytes, _ = io.ReadAll(body)
 	}
 
-	var response *http.Response
-	var doErr error
-	retries := 0
-	for {
-		request, requestErr := http.NewRequest(method, fullURL, io.NopCloser(bytes.NewBuffer(bodyBytes)))
-		if requestErr != nil {
-			return nil, retries, requestErr
-		}
-
-		request.SetBasicAuth(server.Username, server.Password)
-		request.Header.Set("Accept", "application/json")
-		request.Header.Set("Content-Type", "application/json")
-
-		response, doErr = server.httpClient.Do(request)
-
-		if doErr == nil && response != nil && response.StatusCode != 503 {
-			break
-		}
-
-		if retries >= server.Retries {
-			break
-		}
-		retries++
-		time.Sleep(server.RetryDelay)
+	request, requestErr := http.NewRequest(method, fullURL, io.NopCloser(bytes.NewBuffer(bodyBytes)))
+	if requestErr != nil {
+		return nil, requestErr
 	}
 
-	return response, retries, doErr
+	request.SetBasicAuth(server.Username, server.Password)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+
+	return server.httpClient.Do(request)
 }
 
-func (server *Server) Connect() (int, error) {
+func (server *Server) Connect() error {
 
-	response, retries, doErr := server.doRequest("GET", server.BaseURL, nil)
+	response, doErr := server.doRequest("GET", server.BaseURL, nil)
 
-	if (doErr != nil) || (response == nil || response.StatusCode == 503) {
+	if doErr != nil || response == nil {
 		server.httpClient = nil
-		return retries, doErr
+		return doErr
 	}
 
 	defer response.Body.Close()
 
-	return retries, nil
+	return nil
 }
 
 // NewAPIRequest ...
 func (server *Server) NewAPIRequest(method, APICall string, jsonString []byte) (*APIResult, error) {
-
-	response, retries, doErr := server.doRequest(method, server.BaseURL+APICall, bytes.NewBuffer(jsonString))
-
-	if doErr != nil {
-		results := APIResult{
-			Code:        0,
-			Status:      "Error : Request to server failed : " + doErr.Error(),
-			ErrorString: doErr.Error(),
-			Retries:     retries,
+	operation := func() (*APIResult, error) {
+		response, doErr := server.doRequest(method, server.BaseURL+APICall, bytes.NewBuffer(jsonString))
+		if doErr != nil {
+			results := &APIResult{
+				Code:        0,
+				Status:      "Error : Request to server failed : " + doErr.Error(),
+				ErrorString: doErr.Error(),
+			}
+			return results, backoff.Permanent(doErr)
 		}
-		return &results, doErr
-	}
-	defer response.Body.Close()
+		defer response.Body.Close()
 
-	var results APIResult
-	if decodeErr := json.NewDecoder(response.Body).Decode(&results); decodeErr != nil {
-		return nil, decodeErr
-	}
+		results := &APIResult{}
+		if decodeErr := json.NewDecoder(response.Body).Decode(&results); decodeErr != nil {
+			return nil, backoff.Permanent(decodeErr)
+		}
 
-	if results.Retries == 0 { // results.Retries have default value so set it.
-		results.Retries = retries
-	}
+		if results.Code == 0 {
+			results.Code = response.StatusCode
+		}
 
-	if results.Code == 0 { // results.Code has default value so set it.
-		results.Code = response.StatusCode
-	}
+		if results.Status == "" {
+			results.Status = response.Status
+		}
 
-	if results.Status == "" { // results.Status has default value, so set it.
-		results.Status = response.Status
-	}
-
-	switch results.Code {
-	case 0:
-		results.ErrorString = "Did not get a response code."
-	case 404:
 		results.ErrorString = results.Status
-	case 200:
-		results.ErrorString = results.Status
-	default:
-		results.ErrorString = results.Status
-		//theError := strings.Replace(results.Results.([]interface{})[0].(map[string]interface{})["errors"].([]interface{})[0].(string), "\n", " ", -1)
-		//results.ErrorString = strings.Replace(theError, "Error: ", "", -1)
+		if response.StatusCode == 0 {
+			results.ErrorString = "Did not get a response code."
+		}
 
+		// Retry when Icinga is reloading
+		// The error message returned by Icinga can have a dot ("Icinga is reloading.") or not ("Icinga is reloading")
+		if results.Code == http.StatusServiceUnavailable && strings.HasPrefix(results.Status, "Icinga is reloading") {
+			return results, fmt.Errorf("icinga is reloading")
+		}
+
+		return results, nil
 	}
 
-	return &results, nil
+	ctx := context.Background()
 
+	// Number of tries must be at least 1 to avoid infinite loop
+	tries := uint(math.Max(float64(server.Tries), 1.0))
+
+	return backoff.Retry(ctx, operation, backoff.WithBackOff(backoff.NewConstantBackOff(server.RetryDelay)), backoff.WithMaxTries(tries))
 }

--- a/iapi/client_test.go
+++ b/iapi/client_test.go
@@ -1,9 +1,12 @@
 package iapi
 
 import (
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
 )
 
 var ICINGA2_API_USER = os.Getenv("ICINGA2_API_USER")
@@ -38,25 +41,22 @@ func TestConnect(t *testing.T) {
 	}
 }
 
-func TestConnectServerUnavailable(t *testing.T) {
-
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", ICINGA2_INSECURE_SKIP_TLS_VERIFY, 5, 0, nil}
-	retries, err := Icinga2_Server.Connect()
-
-	if err == nil {
-		t.Errorf("Error : Did not get error connecting to unavailable server.")
-	}
-	if retries != 5 {
-		t.Errorf("Error : Did not get error connecting to unavailable server before 5 retries.")
-	}
-}
-
 func TestConnectWithBadCredential(t *testing.T) {
 
 	var Icinga2_Server = Server{"unknownUser", "unknownPW", ICINGA2_API_URL, ICINGA2_INSECURE_SKIP_TLS_VERIFY, 0, 0, nil}
-	_, err := Icinga2_Server.Connect()
+	err := Icinga2_Server.Connect()
 	if err != nil {
 		t.Errorf("Did not fail with bad credentials : %s", err)
+	}
+}
+
+func TestConnectServerBadURINoVersion(t *testing.T) {
+
+	var Icinga2_Server = Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, 0, 0, nil}
+	result, _ := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
+
+	if result.Code != 404 {
+		t.Errorf("Error : Did not get expected 404 error connection to bad URI, with no version.")
 	}
 }
 
@@ -69,25 +69,86 @@ func TestNewAPIRequest(t *testing.T) {
 	}
 }
 
-func TestNewAPIRequestServerUnavailable(t *testing.T) {
+func TestNewAPIRequestWhileReloading(t *testing.T) {
+	mockTransport := httpmock.NewMockTransport()
+	mockTransport.RegisterResponder("GET", "https://127.0.0.1:5665/status",
+		httpmock.ResponderFromMultipleResponses(
+			[]*http.Response{
+				httpmock.NewStringResponse(http.StatusServiceUnavailable, `{"status":"Icinga is reloading"}`),
+				httpmock.NewStringResponse(http.StatusOK, `{}`),
+			},
+			t.Log),
+	)
 
-	var Icinga2_Server = Server{"icinga-test", "icinga", "https://127.0.0.1:4665/v1", ICINGA2_INSECURE_SKIP_TLS_VERIFY, 5, 0, nil}
-	result, err := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
+	tries := 0
+	server := Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, tries, 0, nil}
+	server.createHttpClient()
+	server.httpClient.Transport = mockTransport
+
+	results, err := server.NewAPIRequest("GET", "/status", nil)
 
 	if err == nil {
-		t.Errorf("Error : Did not get error connecting to unavailable server.")
+		t.Errorf("expected error 'icinga is reloading', got nil")
+		return
 	}
-	if result.Retries != 5 {
-		t.Errorf("Error : Did not get error connecting to unavailable server before 5 retries.")
+
+	if results.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected code %d, got %d", http.StatusServiceUnavailable, results.Code)
+	}
+
+	if err.Error() != "icinga is reloading" {
+		t.Errorf("expected error 'icinga is reloading', got '%v'", err)
+	}
+
+	info := mockTransport.GetCallCountInfo()
+	calls, ok := info["GET https://127.0.0.1:5665/status"]
+
+	if !ok {
+		t.Errorf("cannot find mock stats in %v", info)
+		return
+	}
+
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
 	}
 }
 
-func TestConnectServerBadURINoVersion(t *testing.T) {
+func TestNewAPIRequestWhileReloadingWithRetries(t *testing.T) {
+	mockTransport := httpmock.NewMockTransport()
+	mockTransport.RegisterResponder("GET", "https://127.0.0.1:5665/status",
+		httpmock.ResponderFromMultipleResponses(
+			[]*http.Response{
+				httpmock.NewStringResponse(http.StatusServiceUnavailable, `{"status":"Icinga is reloading"}`),
+				httpmock.NewStringResponse(http.StatusOK, `{}`),
+			},
+			t.Log),
+	)
 
-	var Icinga2_Server = Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, 0, 0, nil}
-	result, _ := Icinga2_Server.NewAPIRequest("GET", "/status", nil)
+	tries := 2
+	server := Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, tries, 0, nil}
+	server.createHttpClient()
+	server.httpClient.Transport = mockTransport
 
-	if result.Code != 404 {
-		t.Errorf("Error : Did not get expected 404 error connection to bad URI, with no version.")
+	results, err := server.NewAPIRequest("GET", "/status", nil)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if results.Code != http.StatusOK {
+		t.Errorf("expected code %d, got %d", http.StatusOK, results.Code)
+	}
+
+	info := mockTransport.GetCallCountInfo()
+	calls, ok := info["GET https://127.0.0.1:5665/status"]
+
+	if !ok {
+		t.Errorf("cannot find mock stats in %v", info)
+		return
+	}
+
+	if calls != tries {
+		t.Errorf("expected %d calls, got %d", tries, calls)
 	}
 }

--- a/iapi/structs.go
+++ b/iapi/structs.go
@@ -91,10 +91,9 @@ type HostAttrs struct {
 type APIResult struct {
 	Error       float64 `json:"error"`
 	ErrorString string
-	Status      string      `json:"Status"`
-	Code        int         `json:"Code"`
+	Status      string      `json:"status"`
+	Code        int         `json:"code"`
 	Results     interface{} `json:"results"`
-	Retries     int         `json:"Retries"`
 }
 
 // HostgroupUpdateResult stores the API response after updating a Hostgroup


### PR DESCRIPTION
Before this commit, any call having 503 errors with a Retries defined would cause a retry. This is convenient when Icinga is reloading but not when the library tries to create a host that already exists or use a zone that doesn't exist. They return 503 errors too.

The number of retries should not be added to the API results either because they are not part of Icinga responses.

Instead, rename "retries" to "tries" and use the backoff module with constant tries with a fixed delay. Ensure at least one try. And retry only when Icinga is reloading. The error message can have a dot ("Icinga is reloading.") or not ("Icinga is reloading") so detect only the prefix of the message to cover both cases.

Mock HTTP answers to detect when Icinga is reloading and be sure that the retry logic works.

Links:

- https://github.com/lrsmith/go-icinga2-api/pull/18
- https://github.com/Icinga/terraform-provider-icinga2/pull/134