### PR TITLE
feat: Handle context deadline exceeded for host operations

### DIFF
--- a/iapi/hosts.go
+++ b/iapi/hosts.go
@@ -1,9 +1,15 @@
 package iapi
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
 	"net/http"
+	"net/url"
+
+	"github.com/cenkalti/backoff/v5"
 )
 
 // GetHost ...
@@ -33,8 +39,9 @@ func (server *Server) GetHost(hostname string) ([]HostStruct, error) {
 
 }
 
-// CreateHost ...
-func (server *Server) CreateHost(hostname, address, address6 string, checkCommand string, variables map[string]interface{}, templates []string, groups []string, zone string) ([]HostStruct, error) {
+// CreateHost creates a host.
+// When a context deadline is exceeded, wait for the host to be created if a number of tries is defined.
+func (server *Server) CreateHost(hostname, address, address6 string, checkCommand string, variables map[string]interface{}, templates []string, groups []string, zone string) (hosts []HostStruct, err error) {
 
 	var newAttrs HostAttrs
 	newAttrs.Address = address
@@ -60,21 +67,46 @@ func (server *Server) CreateHost(hostname, address, address6 string, checkComman
 		return nil, marshalErr
 	}
 
-	//fmt.Printf("<payload> %s\n", payloadJSON)
+	// Create the host
+	results, err := server.NewAPIRequest(
+		http.MethodPut,
+		fmt.Sprintf("/objects/hosts/%s", url.PathEscape(hostname)),
+		[]byte(payloadJSON),
+	)
 
-	// Make the API request to create the hosts.
-	results, err := server.NewAPIRequest(http.MethodPut, "/objects/hosts/"+hostname, []byte(payloadJSON))
-	if err != nil {
+	// Ignore context deadline exceeded
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return nil, err
 	}
 
-	if results.Code == 200 {
-		hosts, err := server.GetHost(hostname)
-		return hosts, err
+	// Detect real errors
+	if err == nil && results.Code != 200 {
+		return nil, fmt.Errorf("%s", results.ErrorString)
 	}
 
-	return nil, fmt.Errorf("%s", results.ErrorString)
+	// Wait for the host to be created
+	operation := func() ([]HostStruct, error) {
+		hosts, err := server.GetHost(hostname)
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+		for _, host := range hosts {
+			if host.Name == hostname {
+				return hosts, nil
+			}
+		}
+		return nil, fmt.Errorf("host '%s' not found after creation", hostname)
+	}
 
+	// Number of tries must be at least 1 to avoid infinite loop
+	tries := uint(math.Max(float64(server.Tries), 1.0))
+
+	return backoff.Retry(
+		context.Background(),
+		operation,
+		backoff.WithBackOff(backoff.NewConstantBackOff(server.RetryDelay)),
+		backoff.WithMaxTries(tries),
+	)
 }
 
 // UpdateHost updates a Host with its attrs
@@ -118,18 +150,47 @@ func (server *Server) UpdateHost(name string, attrs HostAttrs) ([]HostStruct, er
 	return server.GetHost(name)
 }
 
-// DeleteHost ...
+// DeleteHost deletes a host.
+// When a context deadline is exceeded, wait for the host to be deleted if a number of tries is defined.
 func (server *Server) DeleteHost(hostname string) error {
-	results, err := server.NewAPIRequest(http.MethodDelete, "/objects/hosts/"+hostname+"?cascade=1", nil)
-	if err != nil {
+	results, err := server.NewAPIRequest(
+		http.MethodDelete,
+		fmt.Sprintf("/objects/hosts/%s?cascade=1", url.PathEscape(hostname)),
+		nil,
+	)
+
+	// Ignore context deadline exceeded
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		return err
 	}
 
-	if results.Code == 200 {
-		return nil
+	// Detect real errors
+	if err == nil && results.Code != 200 {
+		return fmt.Errorf("%s", results.ErrorString)
 	}
 
-	return fmt.Errorf("%s", results.ErrorString)
+	// Wait for the host to be deleted
+	operation := func() (string, error) {
+		exists, err := server.HostExists(hostname)
+		if err != nil {
+			return "", backoff.Permanent(err)
+		}
+		if exists {
+			return "", fmt.Errorf("host '%s' still exists after deletion", hostname)
+		}
+		return "", nil
+	}
+
+	// Number of tries must be at least 1 to avoid infinite loop
+	tries := uint(math.Max(float64(server.Tries), 1.0))
+
+	_, err = backoff.Retry(
+		context.Background(),
+		operation,
+		backoff.WithBackOff(backoff.NewConstantBackOff(server.RetryDelay)),
+		backoff.WithMaxTries(tries),
+	)
+	return err
 }
 
 // HostExists returns true if a Host exists

--- a/iapi/hosts_test.go
+++ b/iapi/hosts_test.go
@@ -1,6 +1,14 @@
 package iapi
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
 
 func TestGetValidHost(t *testing.T) {
 
@@ -134,6 +142,95 @@ func TestCreateHostWithZone(t *testing.T) {
 	}
 }
 
+func TestCreateHostWithDeadlineExceeded(t *testing.T) {
+	hostname := "go-icinga2-api-5"
+	IPAddress := "127.0.0.2"
+	CheckCommand := "hostalive"
+
+	// Mock for CreateHost
+	// Always return context deadline exceeded
+	mockTransport := httpmock.NewMockTransport()
+	mockTransport.RegisterResponder(
+		http.MethodPut,
+		fmt.Sprintf("https://127.0.0.1:5665/objects/hosts/%s", url.PathEscape(hostname)),
+		httpmock.NewErrorResponder(context.DeadlineExceeded),
+	)
+
+	server := Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, 0, 0, nil}
+	server.createHttpClient()
+	server.httpClient.Transport = mockTransport
+
+	_, err := server.CreateHost(hostname, IPAddress, "", CheckCommand, nil, nil, nil, "")
+
+	if err == nil {
+		t.Errorf("expected context deadline exceeded error, got nil")
+	}
+}
+
+func TestCreateHostWithDeadlineExceededAndRetries(t *testing.T) {
+	hostname := "go-icinga2-api-5"
+	IPAddress := "127.0.0.2"
+	CheckCommand := "hostalive"
+
+	mockTransport := httpmock.NewMockTransport()
+
+	// Mock for CreateHost
+	// Return context deadline exceeded
+	mockTransport.RegisterResponder(http.MethodPut,
+		fmt.Sprintf("https://127.0.0.1:5665/objects/hosts/%s", url.PathEscape(hostname)),
+		httpmock.NewErrorResponder(context.DeadlineExceeded),
+	)
+
+	// Mock for GetHost
+	// Return 404 to simulate eventual consistency
+	// Then 200 to ensure the host has been created successfully
+	mockTransport.RegisterResponder(http.MethodGet,
+		fmt.Sprintf("https://127.0.0.1:5665/objects/hosts/%s", url.PathEscape(hostname)),
+		httpmock.ResponderFromMultipleResponses(
+			[]*http.Response{
+				httpmock.NewStringResponse(http.StatusNotFound, `{"error":404,"status":"No objects found."}`),
+				httpmock.NewStringResponse(http.StatusOK, fmt.Sprintf(`{"results":[{"type":"Host","name":"%s","address":"%s","check_command":"%s"}]}`, hostname, IPAddress, CheckCommand)),
+			},
+			t.Log),
+	)
+
+	tries := 2
+	server := Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, tries, 0, nil}
+	server.createHttpClient()
+	server.httpClient.Transport = mockTransport
+
+	_, err := server.CreateHost(hostname, IPAddress, "", CheckCommand, nil, nil, nil, "")
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	info := mockTransport.GetCallCountInfo()
+
+	createHostEndpoint := fmt.Sprintf("%s https://127.0.0.1:5665/objects/hosts/%s", http.MethodPut, url.PathEscape(hostname))
+	createCalls, ok := info[createHostEndpoint]
+
+	if !ok {
+		t.Errorf("cannot find mock stats for '%s' endpoint in %v", createHostEndpoint, info)
+		return
+	}
+
+	if createCalls != 1 {
+		t.Errorf("expected 1 call to CreateHost, got %d", createCalls)
+	}
+
+	getHostEndpoint := fmt.Sprintf("%s https://127.0.0.1:5665/objects/hosts/%s", http.MethodGet, url.PathEscape(hostname))
+	getCalls, ok := info[getHostEndpoint]
+	if !ok {
+		t.Errorf("cannot find mock stats for '%s' endpoint in %v", getHostEndpoint, info)
+		return
+	}
+
+	if getCalls != 2 {
+		t.Errorf("expected 2 calls to GetHost, got %d", getCalls)
+	}
+}
+
 func TestDeleteHost(t *testing.T) {
 
 	hostname := "go-icinga2-api-1"
@@ -149,6 +246,92 @@ func TestDeleteHostDNE(t *testing.T) {
 	err := Icinga2_Server.DeleteHost(hostname)
 	if err.Error() != "No objects found." {
 		t.Error(err)
+	}
+}
+
+func TestDeleteHostWithDeadlineExceeded(t *testing.T) {
+	hostname := "go-icinga2-api-6"
+
+	// Mock for DeleteHost
+	// Always return context deadline exceeded
+	mockTransport := httpmock.NewMockTransport()
+	mockTransport.RegisterResponder(
+		http.MethodDelete,
+		fmt.Sprintf("https://127.0.0.1:5665/objects/hosts/%s", url.PathEscape(hostname)),
+		httpmock.NewErrorResponder(context.DeadlineExceeded),
+	)
+
+	server := Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, 0, 0, nil}
+	server.createHttpClient()
+	server.httpClient.Transport = mockTransport
+
+	err := server.DeleteHost(hostname)
+	if err == nil {
+		t.Errorf("expected context deadline exceeded error, got nil")
+	}
+}
+
+func TestDeleteHostWithDeadlineExceededAndRetries(t *testing.T) {
+	hostname := "go-icinga2-api-6"
+	IPAddress := "127.0.0.2"
+	CheckCommand := "hostalive"
+
+	mockTransport := httpmock.NewMockTransport()
+
+	// Mock for DeleteHost
+	// Return context deadline exceeded
+	mockTransport.RegisterResponder(http.MethodDelete,
+		fmt.Sprintf("https://127.0.0.1:5665/objects/hosts/%s", url.PathEscape(hostname)),
+		httpmock.NewErrorResponder(context.DeadlineExceeded),
+	)
+
+	// Mock for GetHost (via HostExists)
+	// Return 200 to simulate eventual consistency
+	// Then 404 to ensure the host has been deleted successfully
+	mockTransport.RegisterResponder(http.MethodGet,
+		fmt.Sprintf("https://127.0.0.1:5665/objects/hosts/%s", url.PathEscape(hostname)),
+		httpmock.ResponderFromMultipleResponses(
+			[]*http.Response{
+				httpmock.NewStringResponse(http.StatusOK, fmt.Sprintf(`{"results":[{"type":"Host","name":"%s","address":"%s","check_command":"%s"}]}`, hostname, IPAddress, CheckCommand)),
+				httpmock.NewStringResponse(http.StatusNotFound, `{"error":404,"status":"No objects found."}`),
+			},
+			t.Log),
+	)
+
+	tries := 2
+	server := Server{ICINGA2_API_USER, ICINGA2_API_PASSWORD, "https://127.0.0.1:5665", ICINGA2_INSECURE_SKIP_TLS_VERIFY, tries, 0, nil}
+	server.createHttpClient()
+	server.httpClient.Transport = mockTransport
+
+	err := server.DeleteHost(hostname)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	info := mockTransport.GetCallCountInfo()
+
+	deleteHostEndpoint := fmt.Sprintf("%s https://127.0.0.1:5665/objects/hosts/%s", http.MethodDelete, url.PathEscape(hostname))
+	deleteCalls, ok := info[deleteHostEndpoint]
+
+	if !ok {
+		t.Errorf("cannot find mock stats for '%s' endpoint in %v", deleteHostEndpoint, info)
+		return
+	}
+
+	if deleteCalls != 1 {
+		t.Errorf("expected 1 call to DeleteHost, got %d", deleteCalls)
+	}
+
+	getHostEndpoint := fmt.Sprintf("%s https://127.0.0.1:5665/objects/hosts/%s", http.MethodGet, url.PathEscape(hostname))
+	getCalls, ok := info[getHostEndpoint]
+	if !ok {
+		t.Errorf("cannot find mock stats for '%s' endpoint in %v", getHostEndpoint, info)
+		return
+	}
+
+	if getCalls != 2 {
+		t.Errorf("expected 2 calls to GetHost, got %d", getCalls)
 	}
 }
 


### PR DESCRIPTION
When hundred of hosts are created or deleted at the same time, the API can be so slow that a context deadline is reached (1 minute). Even if the call has failed on the client, the resource is created or deleted on the infrastructure after a while. When a context deadline is exceeded, wait for the resource to be created or deleted, if a number of tries is defined.

Links:

- https://github.com/Icinga/terraform-provider-icinga2/pull/134